### PR TITLE
feat: Cooperative redeem & refund policies

### DIFF
--- a/.erb/scripts/download-swap-binaries.ts
+++ b/.erb/scripts/download-swap-binaries.ts
@@ -16,9 +16,9 @@ async function makeFileExecutable(binary: Binary) {
   );
 }
 
-const CLI_VERSION = '0.13.2';
+const CLI_VERSION = '0.13.3';
 // Ensure the value here matches with the one in src/main/cli/dirs.ts
-const CLI_FILE_NAME_VERSION_PREFIX = '0_13_2_';
+const CLI_FILE_NAME_VERSION_PREFIX = '0_13_3_';
 
 const binaries = [
   {

--- a/src/main/cli/dirs.ts
+++ b/src/main/cli/dirs.ts
@@ -14,7 +14,7 @@ import { RpcProcessStateType } from 'models/rpcModel';
 // Ensure the CLI version is updated in both places when updating the CLI version.
 // We need a different name for each CLI version to make sure, that the CLI is definitely updated
 // electron-builder sometimes doesn't update the CLI binary
-const CLI_FILE_NAME_VERSION_PREFIX = '0_13_2_';
+const CLI_FILE_NAME_VERSION_PREFIX = '0_13_3_';
 
 // Be consistent with the way the cli generates the
 // data-dir on linux

--- a/src/main/cli/rpc.ts
+++ b/src/main/cli/rpc.ts
@@ -278,7 +278,7 @@ export async function getSwapInfoBatch(
 
 export async function buyXmr(
   redeemAddress: string,
-  refundAddress: string,
+  refundAddress: string | null,
   provider: Provider,
 ) {
   store.dispatch(
@@ -289,14 +289,22 @@ export async function buyXmr(
     }),
   );
 
+  let params =
+    refundAddress === null
+      ? {
+          monero_receive_address: redeemAddress,
+          seller: providerToConcatenatedMultiAddr(provider),
+        }
+      : {
+          bitcoin_change_address: refundAddress,
+          monero_receive_address: redeemAddress,
+          seller: providerToConcatenatedMultiAddr(provider),
+        };
+
   try {
     await makeRpcRequest<BuyXmrResponse>(
       RpcMethod.BUY_XMR,
-      {
-        bitcoin_change_address: refundAddress,
-        monero_receive_address: redeemAddress,
-        seller: providerToConcatenatedMultiAddr(provider),
-      },
+      params,
       (logs) => {
         store.dispatch(
           swapAddLog({

--- a/src/models/cliModel.ts
+++ b/src/models/cliModel.ts
@@ -414,7 +414,8 @@ export function isCliLogAliceRejectedOurRequestForCooperativeXmrRedeem(
 }
 
 // tracing::error!(?error, "Failed to request cooperative XMR redeem from Alice");
-export interface CliLogFailedToRequestCooperativeXmrRedeemFromAlice extends CliLog {
+export interface CliLogFailedToRequestCooperativeXmrRedeemFromAlice
+  extends CliLog {
   fields: {
     message: 'Failed to request cooperative XMR redeem from Alice';
     error: string;
@@ -425,8 +426,6 @@ export function isCliLogFailedToRequestCooperativeXmrRedeemFromAlice(
   log: CliLog,
 ): log is CliLogFailedToRequestCooperativeXmrRedeemFromAlice {
   return (
-    log.fields.message ===
-    'Failed to request cooperative XMR redeem from Alice'
+    log.fields.message === 'Failed to request cooperative XMR redeem from Alice'
   );
 }
-

--- a/src/models/cliModel.ts
+++ b/src/models/cliModel.ts
@@ -352,22 +352,6 @@ export function isCliLogDownloadingMoneroWalletRpc(
   return log.fields.message === 'Downloading monero-wallet-rpc';
 }
 
-export interface CliLogStartedSyncingMoneroWallet extends CliLog {
-  fields: {
-    message: 'Syncing Monero wallet';
-    current_sync_height?: boolean;
-  };
-}
-
-export interface CliLogDownloadingMoneroWalletRpc extends CliLog {
-  fields: {
-    message: 'Downloading monero-wallet-rpc';
-    progress: string;
-    size: string;
-    download_url: string;
-  };
-}
-
 export interface CliLogGotNotificationForNewBlock extends CliLog {
   fields: {
     message: 'Got notification for new block';
@@ -380,3 +364,69 @@ export function isCliLogGotNotificationForNewBlock(
 ): log is CliLogGotNotificationForNewBlock {
   return log.fields.message === 'Got notification for new block';
 }
+
+export interface CliLogAttemptingToCooperativelyRedeemXmr extends CliLog {
+  fields: {
+    message: 'Attempting to cooperatively redeem XMR after being punished';
+  };
+}
+
+export function isCliLogAttemptingToCooperativelyRedeemXmr(
+  log: CliLog,
+): log is CliLogAttemptingToCooperativelyRedeemXmr {
+  return (
+    log.fields.message ===
+    'Attempting to cooperatively redeem XMR after being punished'
+  );
+}
+
+export interface CliLogAliceHasAcceptedOurRequestToCooperativelyRedeemTheXmr
+  extends CliLog {
+  fields: {
+    message: 'Alice has accepted our request to cooperatively redeem the XMR';
+  };
+}
+
+export function isCliLogAliceHasAcceptedOurRequestToCooperativelyRedeemTheXmr(
+  log: CliLog,
+): log is CliLogAliceHasAcceptedOurRequestToCooperativelyRedeemTheXmr {
+  return (
+    log.fields.message ===
+    'Alice has accepted our request to cooperatively redeem the XMR'
+  );
+}
+
+export interface CliLogAliceRejectedOurRequestForCooperativeXmrRedeem
+  extends CliLog {
+  fields: {
+    message: 'Alice rejected our request for cooperative XMR redeem';
+    reason: string;
+  };
+}
+
+export function isCliLogAliceRejectedOurRequestForCooperativeXmrRedeem(
+  log: CliLog,
+): log is CliLogAliceRejectedOurRequestForCooperativeXmrRedeem {
+  return (
+    log.fields.message ===
+    'Alice rejected our request for cooperative XMR redeem'
+  );
+}
+
+// tracing::error!(?error, "Failed to request cooperative XMR redeem from Alice");
+export interface CliLogFailedToRequestCooperativeXmrRedeemFromAlice extends CliLog {
+  fields: {
+    message: 'Failed to request cooperative XMR redeem from Alice';
+    error: string;
+  };
+}
+
+export function isCliLogFailedToRequestCooperativeXmrRedeemFromAlice(
+  log: CliLog,
+): log is CliLogFailedToRequestCooperativeXmrRedeemFromAlice {
+  return (
+    log.fields.message ===
+    'Failed to request cooperative XMR redeem from Alice'
+  );
+}
+

--- a/src/models/storeModel.ts
+++ b/src/models/storeModel.ts
@@ -35,7 +35,7 @@ export enum SwapStateType {
   BTC_PUNISHED = 'btc punished',
   ATTEMPTING_COOPERATIVE_REDEEM = 'attempting cooperative redeem',
   COOPERATIVE_REDEEM_REJECTED = 'cooperative redeem rejected',
-  COOPERATIVE_REDEEM_ACCEPTED = 'cooperative redeem accepted'
+  COOPERATIVE_REDEEM_ACCEPTED = 'cooperative redeem accepted',
 }
 
 export function isSwapState(state?: SwapState | null): state is SwapState {

--- a/src/models/storeModel.ts
+++ b/src/models/storeModel.ts
@@ -33,6 +33,9 @@ export enum SwapStateType {
   BTC_CANCELLED = 'btc cancelled',
   BTC_REFUNDED = 'btc refunded',
   BTC_PUNISHED = 'btc punished',
+  ATTEMPTING_COOPERATIVE_REDEEM = 'attempting cooperative redeem',
+  COOPERATIVE_REDEEM_REJECTED = 'cooperative redeem rejected',
+  COOPERATIVE_REDEEM_ACCEPTED = 'cooperative redeem accepted'
 }
 
 export function isSwapState(state?: SwapState | null): state is SwapState {
@@ -136,6 +139,37 @@ export function isSwapStateBtcRedemeed(
   state?: SwapState | null,
 ): state is SwapStateBtcRedemeed {
   return state?.type === SwapStateType.BTC_REDEEMED;
+}
+
+export interface SwapStateAttemptingCooperativeRedeeem extends SwapState {
+  type: SwapStateType.ATTEMPTING_COOPERATIVE_REDEEM;
+}
+
+export function isSwapStateAttemptingCooperativeRedeeem(
+  state?: SwapState | null,
+): state is SwapStateAttemptingCooperativeRedeeem {
+  return state?.type === SwapStateType.ATTEMPTING_COOPERATIVE_REDEEM;
+}
+
+export interface SwapStateCooperativeRedeemAccepted extends SwapState {
+  type: SwapStateType.COOPERATIVE_REDEEM_ACCEPTED;
+}
+
+export function isSwapStateCooperativeRedeemAccepted(
+  state?: SwapState | null,
+): state is SwapStateCooperativeRedeemAccepted {
+  return state?.type === SwapStateType.COOPERATIVE_REDEEM_ACCEPTED;
+}
+
+export interface SwapStateCooperativeRedeemRejected extends SwapState {
+  type: SwapStateType.COOPERATIVE_REDEEM_REJECTED;
+  reason: string;
+}
+
+export function isSwapStateCooperativeRedeemRejected(
+  state?: SwapState | null,
+): state is SwapStateCooperativeRedeemRejected {
+  return state?.type === SwapStateType.COOPERATIVE_REDEEM_REJECTED;
 }
 
 export interface SwapStateXmrRedeemInMempool extends SwapState {

--- a/src/renderer/components/alert/SwapStatusAlert.tsx
+++ b/src/renderer/components/alert/SwapStatusAlert.tsx
@@ -221,7 +221,7 @@ export default function SwapStatusAlert({
     <Alert
       key={swap.swapId}
       severity="warning"
-      action={<SwapResumeButton swap={swap} />}
+      action={<SwapResumeButton swap={swap}>Resume</SwapResumeButton>}
       variant="filled"
     >
       <AlertTitle>

--- a/src/renderer/components/alert/UnfinishedSwapsAlert.tsx
+++ b/src/renderer/components/alert/UnfinishedSwapsAlert.tsx
@@ -1,10 +1,10 @@
 import { Button } from '@material-ui/core';
 import Alert from '@material-ui/lab/Alert';
 import { useNavigate } from 'react-router-dom';
-import { useResumeableSwapsCountExclusindPunished } from 'store/hooks';
+import { useResumeableSwapsCountExcludingPunished } from 'store/hooks';
 
 export default function UnfinishedSwapsAlert() {
-  const resumableSwapsCount = useResumeableSwapsCountExclusindPunished();
+  const resumableSwapsCount = useResumeableSwapsCountExcludingPunished();
   const navigate = useNavigate();
 
   if (resumableSwapsCount > 0) {

--- a/src/renderer/components/alert/UnfinishedSwapsAlert.tsx
+++ b/src/renderer/components/alert/UnfinishedSwapsAlert.tsx
@@ -1,10 +1,10 @@
 import { Button } from '@material-ui/core';
 import Alert from '@material-ui/lab/Alert';
 import { useNavigate } from 'react-router-dom';
-import { useResumeableSwapsCount } from 'store/hooks';
+import { useResumeableSwapsCountExclusindPunished } from 'store/hooks';
 
 export default function UnfinishedSwapsAlert() {
-  const resumableSwapsCount = useResumeableSwapsCount();
+  const resumableSwapsCount = useResumeableSwapsCountExclusindPunished();
   const navigate = useNavigate();
 
   if (resumableSwapsCount > 0) {

--- a/src/renderer/components/inputs/BitcoinAddressTextField.tsx
+++ b/src/renderer/components/inputs/BitcoinAddressTextField.tsx
@@ -1,8 +1,9 @@
 import { useEffect } from 'react';
-import { TextField } from '@material-ui/core';
+import { InputAdornment, TextField } from '@material-ui/core';
 import { TextFieldProps } from '@material-ui/core/TextField/TextField';
 import { isBtcAddressValid } from 'utils/conversionUtils';
 import { isTestnet } from 'store/config';
+import BitcoinIcon from '../icons/BitcoinIcon';
 
 export default function BitcoinAddressTextField({
   address,
@@ -35,6 +36,13 @@ export default function BitcoinAddressTextField({
       helperText={address.length > 0 ? errorText || helperText : helperText}
       placeholder={placeholder}
       variant="outlined"
+      InputProps={{
+        startAdornment: (
+          <InputAdornment position="start">
+            <BitcoinIcon />
+          </InputAdornment>
+        )
+      }}
       {...props}
     />
   );

--- a/src/renderer/components/inputs/MoneroAddressTextField.tsx
+++ b/src/renderer/components/inputs/MoneroAddressTextField.tsx
@@ -1,8 +1,9 @@
 import { useEffect } from 'react';
-import { TextField } from '@material-ui/core';
+import { InputAdornment, TextField } from '@material-ui/core';
 import { TextFieldProps } from '@material-ui/core/TextField/TextField';
 import { isXmrAddressValid } from 'utils/conversionUtils';
 import { isTestnet } from 'store/config';
+import MoneroIcon from '../icons/MoneroIcon';
 
 export default function MoneroAddressTextField({
   address,
@@ -33,6 +34,13 @@ export default function MoneroAddressTextField({
       helperText={address.length > 0 ? errorText || helperText : helperText}
       placeholder={placeholder}
       variant="outlined"
+      InputProps={{
+        startAdornment: (
+          <InputAdornment position="start">
+            <MoneroIcon />
+          </InputAdornment>
+        )
+      }}
       {...props}
     />
   );

--- a/src/renderer/components/modal/provider/ProviderInfo.tsx
+++ b/src/renderer/components/modal/provider/ProviderInfo.tsx
@@ -6,6 +6,8 @@ import {
   MoneroBitcoinExchangeRate,
   SatsAmount,
 } from 'renderer/components/other/Units';
+import { isProviderOutdated } from 'utils/multiAddrUtils';
+import WarningIcon from '@material-ui/icons/Warning';
 
 const useStyles = makeStyles((theme) => ({
   content: {
@@ -28,6 +30,7 @@ export default function ProviderInfo({
   provider: ExtendedProviderStatus;
 }) {
   const classes = useStyles();
+  const isOutdated = isProviderOutdated(provider);
 
   return (
     <Box className={classes.content}>
@@ -67,6 +70,11 @@ export default function ProviderInfo({
         {provider.recommended === true && (
           <Tooltip title="This provider has shown to be exceptionally reliable">
             <Chip label="Recommended" icon={<VerifiedUser />} color="primary" />
+          </Tooltip>
+        )}
+        {isOutdated && (
+          <Tooltip title="This provider is running an outdated version of the software. Outdated providers may be unreliable and cause swaps to take longer to complete or fail entirely.">
+            <Chip label="Outdated" icon={<WarningIcon />} color="primary" />
           </Tooltip>
         )}
       </Box>

--- a/src/renderer/components/modal/swap/pages/SwapStatePage.tsx
+++ b/src/renderer/components/modal/swap/pages/SwapStatePage.tsx
@@ -1,11 +1,14 @@
 import { Box } from '@material-ui/core';
 import { useAppSelector } from 'store/hooks';
 import {
+  isSwapStateAttemptingCooperativeRedeeem,
   isSwapStateBtcCancelled,
   isSwapStateBtcLockInMempool,
   isSwapStateBtcPunished,
   isSwapStateBtcRedemeed,
   isSwapStateBtcRefunded,
+  isSwapStateCooperativeRedeemAccepted,
+  isSwapStateCooperativeRedeemRejected,
   isSwapStateInitiated,
   isSwapStateProcessExited,
   isSwapStateReceivedQuote,
@@ -32,6 +35,7 @@ import BitcoinCancelledPage from './in_progress/BitcoinCancelledPage';
 import BitcoinRefundedPage from './done/BitcoinRefundedPage';
 import BitcoinPunishedPage from './done/BitcoinPunishedPage';
 import { SyncingMoneroWalletPage } from './in_progress/SyncingMoneroWalletPage';
+import CircularProgressWithSubtitle from '../CircularProgressWithSubtitle';
 
 export default function SwapStatePage({
   swapState,
@@ -83,8 +87,17 @@ export default function SwapStatePage({
     return <BitcoinRefundedPage state={swapState} />;
   }
   if (isSwapStateBtcPunished(swapState)) {
-    return <BitcoinPunishedPage />;
+    return <BitcoinPunishedPage state={null} />;
   }
+  if(isSwapStateAttemptingCooperativeRedeeem(swapState)) {
+    return <CircularProgressWithSubtitle description="Attempting to redeem the Monero with the help of the other party" />;
+  }
+  if(isSwapStateCooperativeRedeemAccepted(swapState)) {
+    return <CircularProgressWithSubtitle description="The other party is cooperating with us to redeem the Monero..." />;
+  }
+  if(isSwapStateCooperativeRedeemRejected(swapState)) {
+    return <BitcoinPunishedPage state={swapState} />;
+  } 
   if (isSwapStateProcessExited(swapState)) {
     return <ProcessExitedPage state={swapState} />;
   }

--- a/src/renderer/components/modal/swap/pages/SwapStatePage.tsx
+++ b/src/renderer/components/modal/swap/pages/SwapStatePage.tsx
@@ -89,15 +89,19 @@ export default function SwapStatePage({
   if (isSwapStateBtcPunished(swapState)) {
     return <BitcoinPunishedPage state={null} />;
   }
-  if(isSwapStateAttemptingCooperativeRedeeem(swapState)) {
-    return <CircularProgressWithSubtitle description="Attempting to redeem the Monero with the help of the other party" />;
+  if (isSwapStateAttemptingCooperativeRedeeem(swapState)) {
+    return (
+      <CircularProgressWithSubtitle description="Attempting to redeem the Monero with the help of the other party" />
+    );
   }
-  if(isSwapStateCooperativeRedeemAccepted(swapState)) {
-    return <CircularProgressWithSubtitle description="The other party is cooperating with us to redeem the Monero..." />;
+  if (isSwapStateCooperativeRedeemAccepted(swapState)) {
+    return (
+      <CircularProgressWithSubtitle description="The other party is cooperating with us to redeem the Monero..." />
+    );
   }
-  if(isSwapStateCooperativeRedeemRejected(swapState)) {
+  if (isSwapStateCooperativeRedeemRejected(swapState)) {
     return <BitcoinPunishedPage state={swapState} />;
-  } 
+  }
   if (isSwapStateProcessExited(swapState)) {
     return <ProcessExitedPage state={swapState} />;
   }

--- a/src/renderer/components/modal/swap/pages/done/BitcoinPunishedPage.tsx
+++ b/src/renderer/components/modal/swap/pages/done/BitcoinPunishedPage.tsx
@@ -1,17 +1,30 @@
 import { Box, DialogContentText } from '@material-ui/core';
 import FeedbackInfoBox from '../../../../pages/help/FeedbackInfoBox';
-import { SwapStateCooperativeRedeemRejected, isSwapStateCooperativeRedeemRejected } from 'models/storeModel';
+import {
+  SwapStateCooperativeRedeemRejected,
+  isSwapStateCooperativeRedeemRejected,
+} from 'models/storeModel';
 
-export default function BitcoinPunishedPage({state}: {state: null | SwapStateCooperativeRedeemRejected}) {
+export default function BitcoinPunishedPage({
+  state,
+}: {
+  state: null | SwapStateCooperativeRedeemRejected;
+}) {
   return (
     <Box>
       <DialogContentText>
-      Unfortunately, the swap was unsuccessful. Since you did not refund in time, the Bitcoin has been lost. However, with the cooperation of the other party, you might still be able to redeem the Monero, although this is not guaranteed.        {
-          isSwapStateCooperativeRedeemRejected(state) && <>
-            <br/>
-            We tried to redeem the Monero with the other party's help, but it was unsuccessful (reason: {state.reason}). Attempting again at a later time might yield success.            <br/>
+        Unfortunately, the swap was unsuccessful. Since you did not refund in
+        time, the Bitcoin has been lost. However, with the cooperation of the
+        other party, you might still be able to redeem the Monero, although this
+        is not guaranteed.{' '}
+        {isSwapStateCooperativeRedeemRejected(state) && (
+          <>
+            <br />
+            We tried to redeem the Monero with the other party's help, but it
+            was unsuccessful (reason: {state.reason}). Attempting again at a
+            later time might yield success. <br />
           </>
-        }
+        )}
       </DialogContentText>
       <FeedbackInfoBox />
     </Box>

--- a/src/renderer/components/modal/swap/pages/done/BitcoinPunishedPage.tsx
+++ b/src/renderer/components/modal/swap/pages/done/BitcoinPunishedPage.tsx
@@ -1,13 +1,17 @@
 import { Box, DialogContentText } from '@material-ui/core';
 import FeedbackInfoBox from '../../../../pages/help/FeedbackInfoBox';
+import { SwapStateCooperativeRedeemRejected, isSwapStateCooperativeRedeemRejected } from 'models/storeModel';
 
-export default function BitcoinPunishedPage() {
+export default function BitcoinPunishedPage({state}: {state: null | SwapStateCooperativeRedeemRejected}) {
   return (
     <Box>
       <DialogContentText>
-        Unfortunately, the swap was not successful, and you&apos;ve incurred a
-        penalty because the swap was not refunded in time. Both the Bitcoin and
-        Monero are irretrievable.
+      Unfortunately, the swap was unsuccessful. Since you did not refund in time, the Bitcoin has been lost. However, with the cooperation of the other party, you might still be able to redeem the Monero, although this is not guaranteed.        {
+          isSwapStateCooperativeRedeemRejected(state) && <>
+            <br/>
+            We tried to redeem the Monero with the other party's help, but it was unsuccessful (reason: {state.reason}). Attempting again at a later time might yield success.            <br/>
+          </>
+        }
       </DialogContentText>
       <FeedbackInfoBox />
     </Box>

--- a/src/renderer/components/modal/swap/pages/done/XmrRedeemInMempoolPage.tsx
+++ b/src/renderer/components/modal/swap/pages/done/XmrRedeemInMempoolPage.tsx
@@ -4,6 +4,7 @@ import { useActiveSwapInfo } from 'store/hooks';
 import { getSwapXmrAmount } from 'models/rpcModel';
 import MoneroTransactionInfoBox from '../../MoneroTransactionInfoBox';
 import FeedbackInfoBox from '../../../../pages/help/FeedbackInfoBox';
+import { MoneroAmount } from 'renderer/components/other/Units';
 
 type XmrRedeemInMempoolPageProps = {
   state: SwapStateXmrRedeemInMempool | null;
@@ -13,11 +14,13 @@ export default function XmrRedeemInMempoolPage({
   state,
 }: XmrRedeemInMempoolPageProps) {
   const swap = useActiveSwapInfo();
-  const additionalContent = swap
-    ? `This transaction transfers ${getSwapXmrAmount(swap).toFixed(6)} XMR to ${
-        state?.bobXmrRedeemAddress
-      }`
-    : null;
+  const additionalContent = swap ? (
+    <>
+      This transaction transfers{' '}
+      <MoneroAmount amount={getSwapXmrAmount(swap)} /> to the{' '}
+      {state?.bobXmrRedeemAddress}
+    </>
+  ) : null;
 
   return (
     <Box>

--- a/src/renderer/components/modal/swap/pages/exited/ProcessExitedPage.tsx
+++ b/src/renderer/components/modal/swap/pages/exited/ProcessExitedPage.tsx
@@ -3,6 +3,7 @@ import { SwapStateName } from 'models/rpcModel';
 import {
   isSwapStateBtcPunished,
   isSwapStateBtcRefunded,
+  isSwapStateCooperativeRedeemRejected,
   isSwapStateXmrRedeemInMempool,
   SwapStateProcessExited,
 } from '../../../../../../models/storeModel';
@@ -24,7 +25,8 @@ export default function ProcessExitedPage({ state }: ProcessExitedPageProps) {
   if (
     isSwapStateXmrRedeemInMempool(state.prevState) ||
     isSwapStateBtcRefunded(state.prevState) ||
-    isSwapStateBtcPunished(state.prevState)
+    isSwapStateBtcPunished(state.prevState) ||
+    isSwapStateCooperativeRedeemRejected(state.prevState)
   ) {
     return <SwapStatePage swapState={state.prevState} />;
   }

--- a/src/renderer/components/modal/swap/pages/init/InitPage.tsx
+++ b/src/renderer/components/modal/swap/pages/init/InitPage.tsx
@@ -1,4 +1,4 @@
-import { Box, DialogContentText, makeStyles } from '@material-ui/core';
+import { Box, DialogContentText, makeStyles, Paper, Tab, Tabs, Typography } from '@material-ui/core';
 import { useState } from 'react';
 import BitcoinAddressTextField from 'renderer/components/inputs/BitcoinAddressTextField';
 import MoneroAddressTextField from 'renderer/components/inputs/MoneroAddressTextField';
@@ -13,14 +13,19 @@ const useStyles = makeStyles((theme) => ({
     marginTop: theme.spacing(1),
   },
   fieldsOuter: {
+    paddingTop: theme.spacing(1),
     display: 'flex',
     flexDirection: 'column',
-    gap: theme.spacing(2),
+    gap: theme.spacing(1),
   },
 }));
 
 export default function InitPage() {
+  const selectedProvider = useAppSelector(
+    (state) => state.providers.selectedProvider,
+  );
   const classes = useStyles();
+  
   const [redeemAddress, setRedeemAddress] = useState(
     isTestnet() && process.env.TESTNET_AUTOFILL_XMR_ADDRESS
       ? process.env.TESTNET_AUTOFILL_XMR_ADDRESS
@@ -33,54 +38,65 @@ export default function InitPage() {
   );
   const [redeemAddressValid, setRedeemAddressValid] = useState(false);
   const [refundAddressValid, setRefundAddressValid] = useState(false);
-  const selectedProvider = useAppSelector(
-    (state) => state.providers.selectedProvider,
-  );
+  const [useExternalRefundAddress, setUseExternalRefundAddress] = useState(false);
 
   return (
     <Box>
       <RemainingFundsWillBeUsedAlert />
-      <DialogContentText>
-        Please specify the address to which the Monero should be sent upon
-        completion of the swap and the address for receiving a Bitcoin refund if
-        the swap fails.
-      </DialogContentText>
-
       <Box className={classes.fieldsOuter}>
         <MoneroAddressTextField
           label="Monero redeem address"
           address={redeemAddress}
           onAddressChange={setRedeemAddress}
           onAddressValidityChange={setRedeemAddressValid}
-          helperText="The monero will be sent to this address"
+          helperText="The monero will be sent to this address if the swap is successful."
           fullWidth
         />
 
-        <BitcoinAddressTextField
-          label="Bitcoin refund address"
-          address={refundAddress}
-          onAddressChange={setRefundAddress}
-          onAddressValidityChange={setRefundAddressValid}
-          helperText="In case something goes terribly wrong, all Bitcoin will be refunded to this address"
-          fullWidth
-        />
+        <Paper variant="outlined" style={{ }}>
+          <Tabs value={useExternalRefundAddress ? 1 : 0} indicatorColor='primary' variant='fullWidth' onChange={(_, newValue) => setUseExternalRefundAddress(newValue === 1)}>
+            <Tab label="Refund to internal Bitcoin wallet" value={0} />
+            <Tab label="Refund to external Bitcoin address" value={1} />
+          </Tabs>
+          <Box style={{ padding: '16px' }}>
+            {
+              useExternalRefundAddress ? (
+                <BitcoinAddressTextField
+                  label="External Bitcoin refund address"
+                  address={refundAddress}
+                  onAddressChange={setRefundAddress}
+                  onAddressValidityChange={setRefundAddressValid}
+                  helperText="In case something goes wrong, the Bitcoin will be refunded to this address."
+                  fullWidth
+                />
+              ) : (
+                <Typography variant="caption">
+                  In case something goes wrong, the Bitcoin will be refunded to the internal Bitcoin wallet of the GUI. You can then withdraw them from there or use them for another swap directly.
+                </Typography>
+              )
+            }
+          </Box>
+        </Paper>
       </Box>
-
-      <IpcInvokeButton
-        disabled={
-          !refundAddressValid || !redeemAddressValid || !selectedProvider
-        }
-        variant="contained"
-        color="primary"
-        size="large"
-        className={classes.initButton}
-        endIcon={<PlayArrowIcon />}
-        ipcChannel="spawn-buy-xmr"
-        ipcArgs={[selectedProvider, redeemAddress, refundAddress]}
-        displayErrorSnackbar={false}
-      >
-        Start swap
-      </IpcInvokeButton>
+      <Box style={{ display: 'flex', justifyContent: 'center' }}> 
+        <IpcInvokeButton
+          disabled={
+            (!refundAddressValid && useExternalRefundAddress) ||
+            !redeemAddressValid ||
+            !selectedProvider
+          }
+          variant="contained"
+          color="primary"
+          size="large"
+          className={classes.initButton}
+          endIcon={<PlayArrowIcon />}
+          ipcChannel="spawn-buy-xmr"
+          ipcArgs={[selectedProvider, redeemAddress, useExternalRefundAddress ? refundAddress : null]}
+          displayErrorSnackbar={false}
+        >
+          Request quote and start swap
+        </IpcInvokeButton>
+      </Box>
     </Box>
   );
 }

--- a/src/renderer/components/navigation/UnfinishedSwapsCountBadge.tsx
+++ b/src/renderer/components/navigation/UnfinishedSwapsCountBadge.tsx
@@ -1,12 +1,12 @@
 import { Badge } from '@material-ui/core';
-import { useResumeableSwapsCountExclusindPunished } from 'store/hooks';
+import { useResumeableSwapsCountExcludingPunished } from 'store/hooks';
 
 export default function UnfinishedSwapsBadge({
   children,
 }: {
   children: JSX.Element;
 }) {
-  const resumableSwapsCount = useResumeableSwapsCountExclusindPunished();
+  const resumableSwapsCount = useResumeableSwapsCountExcludingPunished();
 
   if (resumableSwapsCount > 0) {
     return (

--- a/src/renderer/components/navigation/UnfinishedSwapsCountBadge.tsx
+++ b/src/renderer/components/navigation/UnfinishedSwapsCountBadge.tsx
@@ -1,12 +1,12 @@
 import { Badge } from '@material-ui/core';
-import { useResumeableSwapsCount } from 'store/hooks';
+import { useResumeableSwapsCountExclusindPunished } from 'store/hooks';
 
 export default function UnfinishedSwapsBadge({
   children,
 }: {
   children: JSX.Element;
 }) {
-  const resumableSwapsCount = useResumeableSwapsCount();
+  const resumableSwapsCount = useResumeableSwapsCountExclusindPunished();
 
   if (resumableSwapsCount > 0) {
     return (

--- a/src/renderer/components/pages/history/table/HistoryRowActions.tsx
+++ b/src/renderer/components/pages/history/table/HistoryRowActions.tsx
@@ -14,6 +14,7 @@ import {
 
 export function SwapResumeButton({
   swap,
+  children,
   ...props
 }: { swap: GetSwapInfoResponse } & ButtonProps) {
   return (
@@ -27,7 +28,7 @@ export function SwapResumeButton({
       requiresRpc
       {...props}
     >
-      Resume
+      {children}
     </IpcInvokeButton>
   );
 }
@@ -80,11 +81,15 @@ export default function HistoryRowActions({
 
   if (swap.stateName === SwapStateName.BtcPunished) {
     return (
-      <Tooltip title="The swap is completed because you have been punished">
-        <ErrorIcon style={{ color: red[500] }} />
+      <Tooltip title="You have been punished. You can attempt to recover the Monero with the help of the other party but that is not guaranteed to work">
+        <SwapResumeButton swap={swap}>
+          Attempt recovery
+        </SwapResumeButton>
       </Tooltip>
     );
   }
 
-  return <SwapResumeButton swap={swap} />;
+  return <SwapResumeButton swap={swap}>
+    Resume
+  </SwapResumeButton>
 }

--- a/src/renderer/components/pages/history/table/HistoryRowActions.tsx
+++ b/src/renderer/components/pages/history/table/HistoryRowActions.tsx
@@ -82,14 +82,10 @@ export default function HistoryRowActions({
   if (swap.stateName === SwapStateName.BtcPunished) {
     return (
       <Tooltip title="You have been punished. You can attempt to recover the Monero with the help of the other party but that is not guaranteed to work">
-        <SwapResumeButton swap={swap}>
-          Attempt recovery
-        </SwapResumeButton>
+        <SwapResumeButton swap={swap}>Attempt recovery</SwapResumeButton>
       </Tooltip>
     );
   }
 
-  return <SwapResumeButton swap={swap}>
-    Resume
-  </SwapResumeButton>
+  return <SwapResumeButton swap={swap}>Resume</SwapResumeButton>;
 }

--- a/src/store/features/providersSlice.ts
+++ b/src/store/features/providersSlice.ts
@@ -1,7 +1,7 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { ExtendedProviderStatus, ProviderStatus } from 'models/apiModel';
 import { sortProviderList } from 'utils/sortUtils';
-import { isProviderCompatible } from 'utils/multiAddrUtils';
+import { isProviderOutdated } from 'utils/multiAddrUtils';
 import { getStubTestnetProvider } from 'store/config';
 
 const stubTestnetProvider = getStubTestnetProvider();
@@ -81,13 +81,12 @@ export const providersSlice = createSlice({
       slice,
       action: PayloadAction<ExtendedProviderStatus[]>,
     ) {
+      // Add stub testnet provider if it exists
       if (stubTestnetProvider) {
         action.payload.push(stubTestnetProvider);
       }
 
-      slice.registry.providers = sortProviderList(action.payload).filter(
-        isProviderCompatible,
-      );
+      slice.registry.providers = sortProviderList(action.payload);
       slice.selectedProvider = selectNewSelectedProvider(slice);
     },
     increaseFailedRegistryReconnectAttemptsSinceLastSuccess(slice) {

--- a/src/store/features/swapSlice.ts
+++ b/src/store/features/swapSlice.ts
@@ -263,27 +263,31 @@ export const swapSlice = createSlice({
           };
 
           slice.state = nextState;
-        } else if (isCliLogAliceRejectedOurRequestForCooperativeXmrRedeem(log)) {
+        } else if (
+          isCliLogAliceRejectedOurRequestForCooperativeXmrRedeem(log)
+        ) {
           const nextState: SwapStateCooperativeRedeemRejected = {
             type: SwapStateType.COOPERATIVE_REDEEM_REJECTED,
             reason: log.fields.reason,
           };
 
           slice.state = nextState;
-        } else if (isCliLogAliceHasAcceptedOurRequestToCooperativelyRedeemTheXmr(log)) {
+        } else if (
+          isCliLogAliceHasAcceptedOurRequestToCooperativelyRedeemTheXmr(log)
+        ) {
           const nextState: SwapStateCooperativeRedeemAccepted = {
             type: SwapStateType.COOPERATIVE_REDEEM_ACCEPTED,
           };
 
           slice.state = nextState;
-        } else if(isCliLogFailedToRequestCooperativeXmrRedeemFromAlice(log)) {
+        } else if (isCliLogFailedToRequestCooperativeXmrRedeemFromAlice(log)) {
           const nextState: SwapStateCooperativeRedeemRejected = {
             type: SwapStateType.COOPERATIVE_REDEEM_REJECTED,
             reason: 'Failed to connect to Alice: ' + log.fields.error,
           };
 
           slice.state = nextState;
-        }else if (
+        } else if (
           isCliLogReleasingSwapLockLog(log) &&
           !action.payload.isFromRestore
         ) {

--- a/src/store/hooks.ts
+++ b/src/store/hooks.ts
@@ -20,7 +20,7 @@ export function useResumeableSwapsCount(
   );
 }
 
-export function useResumeableSwapsCountExclusindPunished() {
+export function useResumeableSwapsCountExcludingPunished() {
   return useResumeableSwapsCount(
     (s) => s.stateName !== SwapStateName.BtcPunished,
   );

--- a/src/store/hooks.ts
+++ b/src/store/hooks.ts
@@ -8,17 +8,22 @@ import { GetSwapInfoResponse, SwapStateName } from 'models/rpcModel';
 export const useAppDispatch = () => useDispatch<AppDispatch>();
 export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;
 
-export function useResumeableSwapsCount(filter?: (s: GetSwapInfoResponse) => boolean) {
+export function useResumeableSwapsCount(
+  filter?: (s: GetSwapInfoResponse) => boolean,
+) {
   return useAppSelector(
     (state) =>
       Object.values(state.rpc.state.swapInfos).filter(
-        (swapInfo) => !swapInfo.completed && (filter == null || filter(swapInfo))
+        (swapInfo) =>
+          !swapInfo.completed && (filter == null || filter(swapInfo)),
       ).length,
   );
 }
 
 export function useResumeableSwapsCountExclusindPunished() {
-  return useResumeableSwapsCount(s => s.stateName !== SwapStateName.BtcPunished);
+  return useResumeableSwapsCount(
+    (s) => s.stateName !== SwapStateName.BtcPunished,
+  );
 }
 
 export function useIsSwapRunning() {

--- a/src/store/hooks.ts
+++ b/src/store/hooks.ts
@@ -2,18 +2,23 @@ import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux';
 import type { AppDispatch, RootState } from 'renderer/store/storeRenderer';
 import { sortBy } from 'lodash';
 import { parseDateString } from 'utils/parseUtils';
+import { GetSwapInfoResponse, SwapStateName } from 'models/rpcModel';
 
 // Use throughout your app instead of plain `useDispatch` and `useSelector`
 export const useAppDispatch = () => useDispatch<AppDispatch>();
 export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;
 
-export function useResumeableSwapsCount() {
+export function useResumeableSwapsCount(filter?: (s: GetSwapInfoResponse) => boolean) {
   return useAppSelector(
     (state) =>
       Object.values(state.rpc.state.swapInfos).filter(
-        (swapInfo) => !swapInfo.completed,
+        (swapInfo) => !swapInfo.completed && (filter == null || filter(swapInfo))
       ).length,
   );
+}
+
+export function useResumeableSwapsCountExclusindPunished() {
+  return useResumeableSwapsCount(s => s.stateName !== SwapStateName.BtcPunished);
 }
 
 export function useIsSwapRunning() {

--- a/src/utils/multiAddrUtils.ts
+++ b/src/utils/multiAddrUtils.ts
@@ -3,7 +3,7 @@ import semver from 'semver';
 import { ExtendedProviderStatus, Provider } from 'models/apiModel';
 import { isTestnet } from 'store/config';
 
-const MIN_ASB_VERSION = '0.12.0';
+const MIN_ASB_VERSION = '0.13.3';
 
 export function providerToConcatenatedMultiAddr(provider: Provider) {
   return new Multiaddr(provider.multiAddr)
@@ -11,14 +11,19 @@ export function providerToConcatenatedMultiAddr(provider: Provider) {
     .toString();
 }
 
+export function isProviderOutdated(provider: ExtendedProviderStatus): boolean {
+  if (provider.version) {
+    if (semver.satisfies(provider.version, `>=${MIN_ASB_VERSION}`))
+      return false;
+  } else {
+    return false;
+  }
+
+  return true;
+}
+
 export function isProviderCompatible(
   provider: ExtendedProviderStatus,
 ): boolean {
-  if (provider.version) {
-    if (!semver.satisfies(provider.version, `>=${MIN_ASB_VERSION}`))
-      return false;
-  }
-  if (provider.testnet !== isTestnet()) return false;
-
-  return true;
+  return provider.testnet === isTestnet();
 }

--- a/src/utils/sortUtils.ts
+++ b/src/utils/sortUtils.ts
@@ -1,19 +1,23 @@
 import { ExtendedProviderStatus } from 'models/apiModel';
+import { isProviderCompatible } from './multiAddrUtils';
 
 export function sortProviderList(list: ExtendedProviderStatus[]) {
-  return list.concat().sort((firstEl, secondEl) => {
-    // If neither of them have a relevancy score, sort by max swap amount
-    if (firstEl.relevancy === undefined && secondEl.relevancy === undefined) {
-      if (firstEl.maxSwapAmount > secondEl.maxSwapAmount) {
+  return list
+    .filter(isProviderCompatible)
+    .concat()
+    .sort((firstEl, secondEl) => {
+      // If neither of them have a relevancy score, sort by max swap amount
+      if (firstEl.relevancy === undefined && secondEl.relevancy === undefined) {
+        if (firstEl.maxSwapAmount > secondEl.maxSwapAmount) {
+          return -1;
+        }
+      }
+      // If only on of the two don't have a relevancy score, prioritize the one that does
+      if (firstEl.relevancy === undefined) return 1;
+      if (secondEl.relevancy === undefined) return -1;
+      if (firstEl.relevancy > secondEl.relevancy) {
         return -1;
       }
-    }
-    // If only on of the two don't have a relevancy score, prioritize the one that does
-    if (firstEl.relevancy === undefined) return 1;
-    if (secondEl.relevancy === undefined) return -1;
-    if (firstEl.relevancy > secondEl.relevancy) {
-      return -1;
-    }
-    return 1;
-  });
+      return 1;
+    });
 }


### PR DESCRIPTION
- Implement cooperative XMR redemption for punished swaps
- Add new swap states: ATTEMPTING_COOPERATIVE_REDEEM, COOPERATIVE_REDEEM_ACCEPTED, COOPERATIVE_REDEEM_REJECTED
- Update swap slice to handle new cooperative redeem logs
- Add toggle in InitPage for internal/external Bitcoin refund address
- Show warning chip for outdated providers
- Enhance BitcoinAddressTextField and MoneroAddressTextField with icons
- Use MoneroAmount component on XmrRedeemInMempoolPage page
- Modify buyXmr to accept optional refund address
- Upgrade CLI to version 0.13.3
- Update minimum ASB version to 0.13.3
- Separate provider compatibility and outdated status checks