### PR TITLE
feat: Allow user to override electrum rpc and modify default one

### DIFF
--- a/release/app/package-lock.json
+++ b/release/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "unstoppableswap-gui",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "unstoppableswap-gui",
-      "version": "0.6.3",
+      "version": "0.6.4",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/release/app/package.json
+++ b/release/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unstoppableswap-gui",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "Graphical User Interface for XMR<>BTC Atomic Swaps",
   "main": "./dist/main/main.js",
   "scripts": {

--- a/src/main/cli/cli.ts
+++ b/src/main/cli/cli.ts
@@ -6,7 +6,7 @@ import {
 import PQueue from 'p-queue';
 import pidtree from 'pidtree';
 import util from 'util';
-import { getPlatform, isTestnet } from 'store/config';
+import { getElectrumRpcUrl, getPlatform, isTestnet } from 'store/config';
 import { CliLog, isCliLog } from 'models/cliModel';
 import { getLogsAndStringsFromRawFileString } from 'utils/parseUtils';
 import { store } from 'main/store/mainStore';
@@ -284,6 +284,7 @@ export async function startRPC() {
     'start-daemon',
     {
       'server-address': `${RPC_BIND_HOST}:${RPC_BIND_PORT}`,
+      'electrum-rpc': getElectrumRpcUrl(),
     },
     async (logs) => {
       RPC_LOG_EVENT_EMITTER.emit(logs.filter(isCliLog));

--- a/src/store/config.ts
+++ b/src/store/config.ts
@@ -1,5 +1,8 @@
 import { ExtendedProviderStatus } from 'models/apiModel';
 
+const DEFAULT_MAINNET_ELECTRUM_RPC_URL = 'tcp://blockstream.info:110';
+const DEFAULT_TESTNET_ELECTRUM_RPC_URL = 'ssl://testnet.foundation.xyz:50002';
+
 export const isTestnet = () =>
   process.env.TESTNET?.toString().toLowerCase() === 'true';
 
@@ -51,5 +54,15 @@ export const getPlatform = () => {
 };
 
 export function getElectrumRpcUrl(): string {
-  return process.env.OVERRIDE_ELECTRUM_RPC_URL ?? 'tcp://blockstream.info:110';
+  if (isTestnet()) {
+    // If running on testnet, return the testnet Electrum RPC URL from environment variable or use the default
+    return (
+      process.env.OVERRIDE_TESTNET_ELECTRUM_RPC_URL ??
+      DEFAULT_TESTNET_ELECTRUM_RPC_URL
+    );
+  }
+  // If running on mainnet, return the mainnet Electrum RPC URL from environment variable or use the default
+  return (
+    process.env.OVERRIDE_ELECTRUM_RPC_URL ?? DEFAULT_MAINNET_ELECTRUM_RPC_URL
+  );
 }

--- a/src/store/config.ts
+++ b/src/store/config.ts
@@ -49,3 +49,7 @@ export const getPlatform = () => {
       return 'linux';
   }
 };
+
+export function getElectrumRpcUrl(): string {
+  return process.env.OVERRIDE_ELECTRUM_RPC_URL ?? 'tcp://blockstream.info:110';
+}


### PR DESCRIPTION
- Changed the default electrum rpc to `tcp://blockstream.info:110`. This is enforced by the GUI. The default one in https://github.com/comit-network/xmr-btc-swap/ has not been changed yet. 
- Users can override the electrum rpc url by setting the `OVERRIDE_ELECTRUM_RPC_URL` /  `OVERRIDE_TESTNET_ELECTRUM_RPC_URL` environment variable.

The [rewrite](https://github.com/UnstoppableSwap/core) of the GUI will allow this to be changed within the GUI.

This PR closes https://github.com/UnstoppableSwap/unstoppableswap-gui/issues/221